### PR TITLE
Avoid error thrown by BigNumber due to too many significant numbers

### DIFF
--- a/src/number-unit.js
+++ b/src/number-unit.js
@@ -15,7 +15,7 @@ export default class NumberUnit {
 
   constructor (number, unit, { strict } = {}) {
     // assert(unit instanceof Unit, 'Must specify type of Unit.')
-    this._number = new Decimal(number)
+    this._number = new Decimal(+('' + number) === 0 ? number : ('' + number))
     this.unit = unit
 
     // TODO: make these getters

--- a/tests/number-unit_significant-figures.test.js
+++ b/tests/number-unit_significant-figures.test.js
@@ -1,0 +1,9 @@
+import test from 'tape-catch'
+import { bitcoin } from './_fixtures'
+
+test('should not error out on significant figures', function (t) {
+  const b1 = bitcoin.BTC(3516.2695380859077)
+  t.equals(b1.unitName, 'BTC')
+  t.equals(b1.toString(), '3516.2695380859077 BTC')
+  t.end()
+})

--- a/tests/number-unit_significant-figures.test.js
+++ b/tests/number-unit_significant-figures.test.js
@@ -1,9 +1,39 @@
 import test from 'tape-catch'
 import { bitcoin } from './_fixtures'
+import NumberUnit from '../'
 
 test('should not error out on significant figures', function (t) {
-  const b1 = bitcoin.BTC(3516.2695380859077)
-  t.equals(b1.unitName, 'BTC')
-  t.equals(b1.toString(), '3516.2695380859077 BTC')
+  let isNumberUnit = function (x) {
+    return x !== undefined && x !== null && x.constructor && x.constructor.name === NumberUnit.name
+  }
+
+  let b1 = null
+  try {
+    b1 = bitcoin.BTC(3516.2695380859077) // 17 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b1), 'Creation of NumberUnit with number 3516.2695380859077 was successful')
+
+  let b2 = null
+  try {
+    b2 = bitcoin.BTC(3516.26953808590) // 15 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b2), 'Creation of NumberUnit with number 3516.26953808590 was successful')
+
+  let b3 = null
+  try {
+    b3 = bitcoin.BTC(351626953808590.7) // 16 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b3), 'Creation of NumberUnit with number 351626953808590.7 was successful')
+
+  let b4 = null
+  try {
+    b4 = bitcoin.BTC(35162695380859.1) // 15 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b4), 'Creation of NumberUnit with number 35162695380859.1 was successful')
+
   t.end()
 })


### PR DESCRIPTION
To avoid error from BigNumber on number with more than 15 significant figures, pass it as string but doing so will fail -0 'is negative' test because -0.toString() is '0', so make zero as an exception